### PR TITLE
Install Active Storage extension lazily

### DIFF
--- a/lib/action_text/engine.rb
+++ b/lib/action_text/engine.rb
@@ -12,9 +12,7 @@ module ActionText
     end
 
     initializer "action_text.active_storage_extension" do
-      require "active_storage/blob"
-
-      class ActiveStorage::Blob
+      ActiveSupport.on_load(:active_storage_blob) do
         include ActionText::Attachable
 
         def previewable_attachable?


### PR DESCRIPTION
Avoid eagerly loading Active Record during app boot. Reinstall the extension when `ActiveStorage::Blob` is reloaded in dev.