### PR TITLE
Added shortcut for easier access to plain_text on Content

### DIFF
--- a/lib/action_text/attribute.rb
+++ b/lib/action_text/attribute.rb
@@ -27,6 +27,10 @@ module ActionText
             self.rich_text_#{name} ||= ActionText::RichText.new(name: "#{name}", record: self)
           end
 
+          def plain_#{name}
+            #{name}.body.to_plain_text
+          end
+
           def #{name}=(body)
             #{name}.body = body
           end

--- a/lib/action_text/attribute.rb
+++ b/lib/action_text/attribute.rb
@@ -12,6 +12,8 @@ module ActionText
       #
       #   message = Message.create!(content: "<h1>Funny times!</h1>")
       #   message.content.to_s # => "<h1>Funny times!</h1>"
+      #   message.plain_content # => "Funny times!"
+      #   or
       #   message.content.body.to_plain_text # => "Funny times!"
       #
       # The dependent RichText model will also automatically process attachments links as sent via the Trix-powered editor.

--- a/test/dummy/app/views/messages/show.html.erb
+++ b/test/dummy/app/views/messages/show.html.erb
@@ -5,8 +5,15 @@
   <%= @message.subject %>
 </p>
 
+<strong>HTML Content:</strong>
+
 <div class="trix-content">
-  <%= @message.content.html_safe %>
+  <%= @message.content %>
+</div>
+
+<strong>Plain Content:</strong>
+<div>
+  <%= @message.plain_content %>
 </div>
 
 <%= link_to 'Edit', edit_message_path(@message) %> |

--- a/test/unit/model_test.rb
+++ b/test/unit/model_test.rb
@@ -6,6 +6,11 @@ class ActionText::ModelTest < ActiveSupport::TestCase
     assert_equal "Hello world", message.content.body.to_plain_text
   end
 
+  test "plain text shortcut" do
+    message = Message.new(subject: "Greetings", content: "<h1>Hello world</h1>")
+    assert_equal "Hello world", message.plain_content
+  end
+
   test "without content" do
     message = Message.create!(subject: "Greetings")
     assert message.content.body.nil?


### PR DESCRIPTION
Instead of:

`message.content.body.to_plain_text`
just call
`message.plain_content`

Also did a minor fix in dummy app.