### PR TITLE
Add "sanitized" to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Then refer to this field in the form for the model:
 <% end %>
 ```
 
-And finally display the rich text on a page:
+And finally display the sanitized rich text on a page:
 
 ```erb
 <%= @message.content %>


### PR DESCRIPTION
I think a prime concern people have here is sanitization and security.
Adding this word to the readme provides a little bit of clarity and
reassurance that we aren't just rendering raw data trusted from the
client.