### PR TITLE
Fix has_rich_text with `:body` keywords error.

### DIFF
--- a/lib/action_text/attribute.rb
+++ b/lib/action_text/attribute.rb
@@ -28,7 +28,7 @@ module ActionText
           end
 
           def #{name}=(body)
-            #{name}.body = body
+            self.#{name}.body = body
           end
         CODE
 

--- a/test/dummy/app/models/message.rb
+++ b/test/dummy/app/models/message.rb
@@ -1,3 +1,4 @@
 class Message < ApplicationRecord
   has_rich_text :content
+  has_rich_text :body
 end

--- a/test/unit/model_test.rb
+++ b/test/unit/model_test.rb
@@ -29,4 +29,9 @@ class ActionText::ModelTest < ActiveSupport::TestCase
     message = Message.create!(subject: "Greetings", content: "<h1>Hello world</h1>")
     assert_equal "Hello world", message.content.to_plain_text
   end
+
+  test "save body" do
+    message = Message.create(subject: "Greetings", body: "<h1>Hello world</h1>")
+    assert_equal "Hello world", message.body.to_plain_text
+  end
 end


### PR DESCRIPTION
In sometimes we may want use `body` as the attribute name.

```rb
class Article < ApplicationRecord
  has_rich_text :body
end
```

<img width="477" alt="2018-10-06 11 08 27" src="https://user-images.githubusercontent.com/5518/46566851-0a7c7100-c959-11e8-953b-b91eda5a9747.png">


This fix for avoid `body` keywords issue.