### PR TITLE
Fix `uninitialized constant ActionText:: ALLOWED_TAGS` error on Rails reload

### DIFF
--- a/app/helpers/action_text/content_helper.rb
+++ b/app/helpers/action_text/content_helper.rb
@@ -1,9 +1,9 @@
 module ActionText
-  SANITIZER          = Rails::Html::Sanitizer.white_list_sanitizer
-  ALLOWED_TAGS       = SANITIZER.allowed_tags + [ ActionText::Attachment::TAG_NAME, "figure", "figcaption" ]
-  ALLOWED_ATTRIBUTES = SANITIZER.allowed_attributes + ActionText::Attachment::ATTRIBUTES
-
   module ContentHelper
+    SANITIZER          = Rails::Html::Sanitizer.white_list_sanitizer
+    ALLOWED_TAGS       = SANITIZER.allowed_tags + [ ActionText::Attachment::TAG_NAME, "figure", "figcaption" ]
+    ALLOWED_ATTRIBUTES = SANITIZER.allowed_attributes + ActionText::Attachment::ATTRIBUTES
+
     def render_action_text_content(content)
       content = content.render_attachments do |attachment|
         unless attachment.in?(content.gallery_attachments)
@@ -22,7 +22,7 @@ module ActionText
         end.chomp
       end
 
-      sanitize content.to_html, tags: ActionText::ALLOWED_TAGS, attributes: ActionText::ALLOWED_ATTRIBUTES
+      sanitize content.to_html, tags: ALLOWED_TAGS, attributes: ALLOWED_ATTRIBUTES
     end
   end
 end


### PR DESCRIPTION
<img width="486" alt="2018-10-06 11 44 45" src="https://user-images.githubusercontent.com/5518/46567067-1159b280-c95e-11e8-9bf7-e60fa11fdcbd.png">

This issue was incorrect constant and file placing, conflict with Rails Autoload.

When Rails reloading, it will remove `ALLOWED_TAGS` constant, and try to search it from `lib/action_text.rb`, but `ALLOWED_TAGS` has defined in `app/helpers/action_text/content_helper.rb`, so autoloader can't load that cosntant.