### PR TITLE
Raise a meaningful error when missing has_rich_text :method

### DIFF
--- a/app/helpers/action_text/tag_helper.rb
+++ b/app/helpers/action_text/tag_helper.rb
@@ -43,6 +43,8 @@ module ActionView::Helpers
     end
 
     def editable_value
+      raise ActionText::MissingHashRichTextError, object: object, method_name: @method_name unless value
+
       value.body.try(:to_trix_html)
     end
   end

--- a/lib/action_text.rb
+++ b/lib/action_text.rb
@@ -1,5 +1,6 @@
 require "active_record"
 require "action_text/engine"
+require "action_text/errors"
 require "nokogiri"
 
 module ActionText

--- a/lib/action_text/errors.rb
+++ b/lib/action_text/errors.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module ActionText
+  # Generic base class for all Action Text exceptions.
+  class Error < StandardError; end
+
+  # Raised when calling rich_text_area within a form without including
+  # `has_rich_text :method_name` class method in the related object.
+  class MissingHashRichTextError < Error
+    def initialize(object:, method_name:)
+      @object, @method_name = object, method_name
+    end
+
+    def to_s
+      "can't access value, possibly missing class method `has_rich_text :#{method_name}`"\
+      " for #{object.class.name} or `:#{method_name}` was misspelled"
+    end
+
+    private
+      attr_reader :object, :method_name
+  end
+end

--- a/test/template/form_helper_test.rb
+++ b/test/template/form_helper_test.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class ActionText::FormHelperTest < ActionView::TestCase
+  test "rich_text_area raises ActionText::MissingHashRichTextError when missing has_rich_text class method" do
+    assert_raises ActionText::MissingHashRichTextError do
+      form_with(model: Message.new, html: { id: "create-message" }) do |form|
+        form.rich_text_area(:undeclared_attribute)
+      end
+    end
+  end
+
+  test "rich_text_area doesn't raise when has_rich_text class method is in place" do
+    assert_nothing_raised do
+      form_with(model: Message.new, html: { id: "create-message" }) do |form|
+        form.rich_text_area(:content)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Summary
When using the rich_text_area form helper if `has_rich_text` class method was missing the following was shown:
```
ActionView::Template::Error (undefined method `body' for nil:NilClass):
    17:   </div>
    18:
    19:   <div class="field">
    20:     <%= form.rich_text_area :content %>
    21:   </div>
    22:
    23:   <div class="actions">
```
This commit introduces a meaningful exception to help the user identify the cause of this error:
```
ActionView::Template::Error (can't access value, possibly missing class method `has_rich_text :content` for Post or `:content` was misspelled):
    17:   </div>
    18:
    19:   <div class="field">
    20:     <%= form.rich_text_area :content %>
    21:   </div>
    22:
    23:   <div class="actions">
```

Fixes #19