### PR TITLE
Add frozen_string_literal: true

### DIFF
--- a/app/helpers/action_text/content_helper.rb
+++ b/app/helpers/action_text/content_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ActionText
   module ContentHelper
     SANITIZER          = Rails::Html::Sanitizer.white_list_sanitizer

--- a/app/helpers/action_text/tag_helper.rb
+++ b/app/helpers/action_text/tag_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ActionText
   module TagHelper
     cattr_accessor(:id, instance_accessor: false) { 0 }

--- a/app/models/action_text/rich_text.rb
+++ b/app/models/action_text/rich_text.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # The RichText record holds the content produced by the Trix editor in a serialized `body` attribute.
 # It also holds all the references to the embedded files, which are stored using Active Storage.
 # This record is then associated with the Active Record model the application desires to have

--- a/bin/test
+++ b/bin/test
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 $: << File.expand_path("../test", __dir__)
 
 require "bundler/setup"

--- a/lib/action_text.rb
+++ b/lib/action_text.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_record"
 require "action_text/engine"
 require "nokogiri"

--- a/lib/action_text/attachable.rb
+++ b/lib/action_text/attachable.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ActionText
   module Attachable
     extend ActiveSupport::Concern

--- a/lib/action_text/attachables/content_attachment.rb
+++ b/lib/action_text/attachables/content_attachment.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ActionText
   module Attachables
     class ContentAttachment

--- a/lib/action_text/attachables/remote_image.rb
+++ b/lib/action_text/attachables/remote_image.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ActionText
   module Attachables
     class RemoteImage

--- a/lib/action_text/attachment.rb
+++ b/lib/action_text/attachment.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ActionText
   class Attachment
     include Attachments::TrixConversion, Attachments::Minification, Attachments::Caching

--- a/lib/action_text/attachment_gallery.rb
+++ b/lib/action_text/attachment_gallery.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ActionText
   class AttachmentGallery
     include ActiveModel::Model

--- a/lib/action_text/attachments/caching.rb
+++ b/lib/action_text/attachments/caching.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ActionText
   module Attachments
     module Caching

--- a/lib/action_text/attachments/minification.rb
+++ b/lib/action_text/attachments/minification.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ActionText
   module Attachments
     module Minification

--- a/lib/action_text/attachments/trix_conversion.rb
+++ b/lib/action_text/attachments/trix_conversion.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ActionText
   module Attachments
     module TrixConversion

--- a/lib/action_text/attribute.rb
+++ b/lib/action_text/attribute.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ActionText
   module Attribute
     extend ActiveSupport::Concern

--- a/lib/action_text/content.rb
+++ b/lib/action_text/content.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ActionText
   class Content
     include Serialization

--- a/lib/action_text/engine.rb
+++ b/lib/action_text/engine.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails/engine"
 
 module ActionText

--- a/lib/action_text/fragment.rb
+++ b/lib/action_text/fragment.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ActionText
   class Fragment
     class << self

--- a/lib/action_text/html_conversion.rb
+++ b/lib/action_text/html_conversion.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ActionText
   module HtmlConversion
     extend self

--- a/lib/action_text/plain_text_conversion.rb
+++ b/lib/action_text/plain_text_conversion.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ActionText
   module PlainTextConversion
     extend self

--- a/lib/action_text/serialization.rb
+++ b/lib/action_text/serialization.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ActionText
   module Serialization
     extend ActiveSupport::Concern

--- a/lib/action_text/trix_attachment.rb
+++ b/lib/action_text/trix_attachment.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ActionText
   class TrixAttachment
     TAG_NAME = "figure"

--- a/lib/action_text/version.rb
+++ b/lib/action_text/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ActionText
   VERSION = '0.1.0'
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Configure Rails Environment
 ENV["RAILS_ENV"] = "test"
 

--- a/test/unit/attachment_test.rb
+++ b/test/unit/attachment_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class ActionText::AttachmentTest < ActiveSupport::TestCase

--- a/test/unit/content_test.rb
+++ b/test/unit/content_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class ActionText::ContentTest < ActiveSupport::TestCase

--- a/test/unit/model_test.rb
+++ b/test/unit/model_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class ActionText::ModelTest < ActiveSupport::TestCase

--- a/test/unit/plain_text_conversion_test.rb
+++ b/test/unit/plain_text_conversion_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class ActionText::PlainTextConversionTest < ActiveSupport::TestCase

--- a/test/unit/trix_attachment_test.rb
+++ b/test/unit/trix_attachment_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class ActionText::TrixAttachmentTest < ActiveSupport::TestCase


### PR DESCRIPTION
### Summary
This patch adds `frozen_string_literal: true` comment on top of all currently existing files.

Additional information
Detected while developing #21 