### PR TITLE
Privatize constants

### DIFF
--- a/lib/action_text/attachment_gallery.rb
+++ b/lib/action_text/attachment_gallery.rb
@@ -56,9 +56,10 @@ module ActionText
       "#<#{self.class.name} size=#{size.inspect}>"
     end
 
-    private
-      TAG_NAME = "div"
-      ATTACHMENT_SELECTOR = "#{ActionText::Attachment::SELECTOR}[presentation=gallery]"
-      SELECTOR = "#{TAG_NAME}:has(#{ATTACHMENT_SELECTOR} + #{ATTACHMENT_SELECTOR})"
+    TAG_NAME = "div"
+    ATTACHMENT_SELECTOR = "#{ActionText::Attachment::SELECTOR}[presentation=gallery]"
+    SELECTOR = "#{TAG_NAME}:has(#{ATTACHMENT_SELECTOR} + #{ATTACHMENT_SELECTOR})"
+
+    private_constant :TAG_NAME, :ATTACHMENT_SELECTOR, :SELECTOR
   end
 end


### PR DESCRIPTION
### Summary
This constants meant to be private but `private_constant` was missing, this patch makes them fully private by adding  `private_constant`.

### Additional information
Detected while developing #21 