### PR TITLE
Prevent rich_text_area from raising when inexistent attribute is passed

### DIFF
--- a/app/helpers/action_text/tag_helper.rb
+++ b/app/helpers/action_text/tag_helper.rb
@@ -45,7 +45,7 @@ module ActionView::Helpers
     end
 
     def editable_value
-      value.body.try(:to_trix_html)
+      value&.body.try(:to_trix_html)
     end
   end
 

--- a/test/template/form_helper_test.rb
+++ b/test/template/form_helper_test.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class ActionText::FormHelperTest < ActionView::TestCase
+  tests ActionText::TagHelper
+
+  def form_with(*)
+    @output_buffer = super
+  end
+
+  test "rich_text_area doesn't raise when attributes don't exist in the model" do
+    assert_nothing_raised do
+      form_with(model: Message.new, scope: :message, id: "create-message") do |form|
+        form.rich_text_area(:not_an_attribute)
+      end
+    end
+
+    assert_match "message[not_an_attribute]", output_buffer
+  end
+end


### PR DESCRIPTION
### Summary
When an inexistent attribute is passed as a parameter to currently existing Rails' Form Helpers they render an empty tag instead of raising an exception. This patch confers the same behavior to
`rich_text_area`.

Fixes #19