### PR TITLE
Remove set_action_text_renderer from dummy app

### DIFF
--- a/test/dummy/app/controllers/application_controller.rb
+++ b/test/dummy/app/controllers/application_controller.rb
@@ -1,8 +1,2 @@
 class ApplicationController < ActionController::Base
-  before_action :set_action_text_renderer
-
-  private
-    def set_action_text_renderer
-      ActionText.renderer = self.class.renderer.new(request.env)
-    end
 end


### PR DESCRIPTION
I don't think we need that since it's set automatically through ActionText::Engine.