### PR TITLE
Enable custom Trix Attachments

### DIFF
--- a/app/models/action_text/rich_text.rb
+++ b/app/models/action_text/rich_text.rb
@@ -15,6 +15,6 @@ class ActionText::RichText < ActiveRecord::Base
   has_many_attached :embeds
 
   before_save do
-    self.embeds = body.attachments.map(&:attachable) if body.present?
+    self.embeds = body.embeddable_attachments.map(&:attachable) if body.present?
   end
 end

--- a/app/views/action_text/attachables/_content_attachment.html.erb
+++ b/app/views/action_text/attachables/_content_attachment.html.erb
@@ -1,0 +1,3 @@
+<% if content_attachment.name == "horizontal-rule" %>
+  <hr>
+<% end %>

--- a/lib/action_text.rb
+++ b/lib/action_text.rb
@@ -35,4 +35,6 @@ module ActionText
     autoload :Minification
     autoload :TrixConversion
   end
+
+  mattr_accessor :attachables, default: []
 end

--- a/lib/action_text/attachable.rb
+++ b/lib/action_text/attachable.rb
@@ -10,9 +10,7 @@ module ActionText
       def from_node(node)
         if attachable = attachable_from_sgid(node["sgid"])
           attachable
-        elsif attachable = ActionText::Attachables::ContentAttachment.from_node(node)
-          attachable
-        elsif attachable = ActionText::Attachables::RemoteImage.from_node(node)
+        elsif attachable = attachable_from_attachables(node)
           attachable
         else
           ActionText::Attachables::MissingAttachable
@@ -26,6 +24,18 @@ module ActionText
       end
 
       private
+        def attachable_from_attachables(node)
+          ActionText.attachables.reduce(nil) do |result, klass|
+            next result if result
+
+            if attachable = klass.from_node(node)
+              result = attachable
+            end
+
+            result
+          end
+        end
+
         def attachable_from_sgid(sgid)
           from_attachable_sgid(sgid)
         rescue ActiveRecord::RecordNotFound

--- a/lib/action_text/content.rb
+++ b/lib/action_text/content.rb
@@ -57,6 +57,10 @@ module ActionText
       self.class.new([self.to_s.presence, *attachments].compact.join("\n"))
     end
 
+    def embeddable_attachments
+      attachments.select { |attachment| attachment.try(:attachable).is_a?(ActiveStorage::Blob) }
+    end
+
     def render_attachments(**options, &block)
       content = fragment.replace(ActionText::Attachment::SELECTOR) do |node|
         block.call(attachment_for_node(node, **options))

--- a/lib/action_text/engine.rb
+++ b/lib/action_text/engine.rb
@@ -1,10 +1,18 @@
 # frozen_string_literal: true
 
 require "rails/engine"
+require "action_text"
+
+require "action_text/attachables/content_attachment"
+require "action_text/attachables/remote_image"
 
 module ActionText
   class Engine < Rails::Engine
     isolate_namespace ActionText
+
+    config.action_text = ActiveSupport::OrderedOptions.new
+    config.action_text.attachables = [ ActionText::Attachables::ContentAttachment, ActionText::Attachables::RemoteImage ]
+
     config.eager_load_namespaces << ActionText
 
     initializer "action_text.attribute" do
@@ -32,6 +40,8 @@ module ActionText
     initializer "action_text.config" do
       config.after_initialize do |app|
         ActionText.renderer ||= ApplicationController.renderer
+
+        ActionText.attachables = app.config.action_text.attachables || []
 
         # FIXME: ApplicationController should have a per-request specific renderer
         # that's been set with the request.env env, and ActionText should just piggyback off

--- a/test/unit/plain_text_conversion_test.rb
+++ b/test/unit/plain_text_conversion_test.rb
@@ -73,6 +73,13 @@ class ActionText::PlainTextConversionTest < ActiveSupport::TestCase
     )
   end
 
+  test "<action-text-attachment content-type=horizontal-rule> tags are converted to their plain-text representation" do
+    assert_converted_to(
+      "Hello world!  ┄ ",
+      %Q(Hello world! <action-text-attachment content-type="vnd.rubyonrails.horizontal-rule.html"><hr></action-text-attachment>)
+    )
+  end
+
   test "preserves non-linebreak whitespace after text" do
     assert_converted_to(
       "Hello world!",


### PR DESCRIPTION
### Summary

This PR enables custom or app-specific [Trix Attachments](https://github.com/basecamp/trix#inserting-a-content-attachment) to be received and stored within the rich text body. The default Trix toolbar and record-based attachments are a great starting point for most apps but perhaps it should be configurable to use other attachments depending on the use case. For example the horizontal rule, or other markup not related to a specific record or file.

The existing `ActionText::Attachables::ContentAttachment` seemed to be heading this direction, so this PR modifies a few things to enable such behavior.

"Attachables" can be registered with `config.action_text.attachables` inspired by ActiveStorage's handling of previewers. The two existing attachables (`ContentAttachment` and `RemoteImage`) have been registered by default.

### Other Information

This also fixes a small bug where `ActionText::RichText` records were not saved if the body contained attachments that were _not_ `ActiveStorage::Blob` instances. The `embeds` were not valid in this case so the record would never update. This switches from embedding all attachments to only those `ActiveStorage::Blob` instances that need to be embedded along with the content.

_I wasn't sure if this was on the coming or desired roadmap for ActionText but thought some customization might be helpful. Happy to revise as needed to make this a reality. (And thanks for this new great framework!)_
