### PR TITLE
only set blobs to the embeds, ignore other attachments

### DIFF
--- a/app/models/action_text/rich_text.rb
+++ b/app/models/action_text/rich_text.rb
@@ -15,6 +15,6 @@ class ActionText::RichText < ActiveRecord::Base
   has_many_attached :embeds
 
   before_save do
-    self.embeds = body.attachments.map(&:attachable) if body.present?
+    self.embeds = body.attachments.map(&:attachable).grep(ActiveStorage::Blob) if body.present?
   end
 end

--- a/test/unit/model_test.rb
+++ b/test/unit/model_test.rb
@@ -36,4 +36,13 @@ class ActionText::ModelTest < ActiveSupport::TestCase
     message = Message.create(subject: "Greetings", body: "<h1>Hello world</h1>")
     assert_equal "Hello world", message.body.to_plain_text
   end
+
+  test "can save content with non-blob attachments" do
+    attachable = Person.create! name: "Javan"
+
+    assert_nothing_raised do
+      message = Message.create(subject: "Greetings", body: %Q(<action-text-attachment sgid="#{attachable.attachable_sgid}"></action-text-attachment>))
+    end
+  end
+
 end


### PR DESCRIPTION
When trying to create content with a `ActionText::Attachable` that is not a Blob, an error is currently being raised `Could not find or build blob: expected attachable` (attachable here referring to Active Storage attachable, not ActionText attachable).

This PR only sets the `ActiveStorage::Blob`s to the embeds, allowing the content to be persisted with other kinds of `ActionText::Attachable`s.