### PR TITLE
CI against Ruby 2.4.5 and 2.5.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 
 rvm:
   - 2.4.5
-  - 2.5.1
+  - 2.5.3
   - ruby-head
 
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: ruby
 sudo: false
 
 rvm:
-  - 2.4.4
+  - 2.4.5
   - 2.5.1
   - ruby-head
 


### PR DESCRIPTION
### Summary
- https://www.ruby-lang.org/en/news/2018/10/17/ruby-2-4-5-released/
- https://www.ruby-lang.org/en/news/2018/10/18/ruby-2-5-3-released/