### PR TITLE
Remove Ruby 2.4 from the CI matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: ruby
 sudo: false
 
 rvm:
-  - 2.4.5
   - 2.5.3
   - ruby-head
 


### PR DESCRIPTION
Rails 6 requires Ruby 2.5+ or newer.
See https://github.com/rails/rails/pull/34754.