### PR TITLE
Use `ActiveRecord::Migration[6.0]`

### DIFF
--- a/db/migrate/201805281641_create_action_text_tables.rb
+++ b/db/migrate/201805281641_create_action_text_tables.rb
@@ -1,4 +1,4 @@
-class CreateActionTextTables < ActiveRecord::Migration[5.2]
+class CreateActionTextTables < ActiveRecord::Migration[6.0]
   def change
     create_table :action_text_rich_texts do |t|
       t.string     :name, null: false


### PR DESCRIPTION
Since Action Text will be part of Rails since version 6.0,
I think it make sense to use `ActiveRecord::Migration[6.0]` in the generated migration.