### PR TITLE
use plain test to determine present/blank/empty

### DIFF
--- a/app/models/action_text/rich_text.rb
+++ b/app/models/action_text/rich_text.rb
@@ -8,8 +8,12 @@ class ActionText::RichText < ActiveRecord::Base
   self.table_name = "action_text_rich_texts"
 
   serialize :body, ActionText::Content
-  delegate :to_s, :to_plain_text, :nil?, to: :body
-  delegate :blank?, :empty?, :present?, to: :to_s
+  delegate :to_s, :nil?, to: :body
+  delegate :blank?, :empty?, :present?, to: :to_plain_text
+
+  def to_plain_text
+    body&.to_plain_text.to_s
+  end
 
   belongs_to :record, polymorphic: true, touch: true
   has_many_attached :embeds

--- a/test/unit/model_test.rb
+++ b/test/unit/model_test.rb
@@ -21,6 +21,14 @@ class ActionText::ModelTest < ActiveSupport::TestCase
     assert_not message.content.present?
   end
 
+  test "with blank content" do
+    message = Message.create!(subject: "Greetings", content: "")
+    assert_not message.content.nil?
+    assert message.content.blank?
+    assert message.content.empty?
+    assert_not message.content.present?
+  end
+
   test "embed extraction" do
     blob = create_file_blob(filename: "racecar.jpg", content_type: "image/jpg")
     message = Message.create!(subject: "Greetings", content: ActionText::Content.new("Hello world").append_attachables(blob))


### PR DESCRIPTION
When setting the content to empty string and then reading it back, you get `"<div class=\"trix-content\">\n  \n</div>\n"` - which means that the `present?`/`empty?`/`blank?` checks always return `true`/`false`/`false` regardless of what the content has been set to.

This PR changes it to use the plain text version for these checks instead. I had to make a `to_plain_text` method instead of delegating so that we could ensure that `to_plain_text` would always return a `String`, otherwise you would get `DelegationError`s.

This prevents the presence validator from working as described in #44

Fixes #44.